### PR TITLE
Fix decorating the language service

### DIFF
--- a/src/template-language-service-decorator.ts
+++ b/src/template-language-service-decorator.ts
@@ -39,17 +39,11 @@ export default class TemplateLanguageServiceProxy {
     }
 
     public decorate(languageService: ts.LanguageService) {
-        const intercept: Partial<ts.LanguageService> = Object.create(null);
-
         for (const { name, wrapper } of this._wrappers) {
-            (intercept[name] as any) = wrapper(languageService[name]!.bind(languageService));
+            languageService[name] = wrapper(languageService[name]?.bind(languageService));
         }
 
-        return new Proxy(languageService, {
-            get: (target: any, property: string | symbol) => {
-                return (intercept as any)[property] || target[property];
-            },
-        });
+        return languageService
     }
 
     private tryAdaptGetSyntaxDiagnostics() {


### PR DESCRIPTION
TypeScript plugins using this library were incompatible with Volar. This is fixed by patching the language service instead of a Proxy object.

I’m not entirely sure why this works, but it does. Hence I’m not sure how to test it. Existing tests pass though.

This is related to https://github.com/mdx-js/mdx-analyzer/issues/451. I confirmed that this change solves that problem by applying them in `node_modules`.